### PR TITLE
chat-spaceのdb設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,55 @@ Things you may want to cover:
 * Configuration
 
 * Database creation
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true, unique: true|
+|group_id|integer|null: false, foreign_key: true, unique: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|message||text|null: false|
+|image||string|
+|user_id|integer|null: false, foreign_key: true, unique: true|
+|group_id|integer|null: false, foreign_key: true, unique: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true, unique: true|
+|user_name|string|null: false|
+|e_mail|string|null: false,　unique: true|
+|passward|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups. through: :groups_users
+- has_many :groups_users
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_id|integer|null: false, foreign_key: true, unique: true|
+|group_name|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :users. thougth: :groups_users
+- has_many :groups_users
 
 * Database initialization
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|message||text|null: false|
+|message||text|
 |image||string|
 |user_id|integer|null: false, foreign_key: true, unique: true|
 |group_id|integer|null: false, foreign_key: true, unique: true|
@@ -40,8 +40,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true, unique: true|
-|user_name|string|null: false|
+|name|string|null: false|
 |e_mail|string|null: false,　unique: true|
 |passward|string|null: false|
 
@@ -54,8 +53,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|group_id|integer|null: false, foreign_key: true, unique: true|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :messages


### PR DESCRIPTION
# What
chat-spaceのdb設計のため、READMEにdb設計の内容を記述いたしました。
今後dbを構築して行くにあたり必須の作業です。

# Why
chat-spaceの作成にあたり、まずdbを作成しなければ、アプリの機能を果たすための情報がdbに保存できません。情報をしっかりとdb内にて保存および管理し、アプリ内で起きる動作にしたがって情報を呼び出したり、管理することができなけば実装が叶わなくなるためです。